### PR TITLE
fix(file-handler): add new line after log message to file

### DIFF
--- a/src/handlers/file.handler.ts
+++ b/src/handlers/file.handler.ts
@@ -41,8 +41,8 @@ export class FileHandler implements LogHandler {
 
     let log = '';
     log += timestamp ? `[${getTimeStamp(timestamp)}] ` : '';
-    log += `[${level}] ${message}`;
-    log += metadata ? `\n${stringify(metadata, 2)}\n` : '';
+    log += `[${level}] ${message}\n`;
+    log += metadata ? `${stringify(metadata, 2)}\n` : '';
 
     writeFileSync(filePath, log, { flag: 'a' });
   }

--- a/test/handlers/file.handler.spec.ts
+++ b/test/handlers/file.handler.spec.ts
@@ -22,7 +22,7 @@ describe('FileHandler', () => {
     const payload: HandlerPayload = { level: LOG_LEVEL.INFO, message: 'hello world' };
     fileHandler.handle(payload);
     const log = readFileSync(path, 'utf-8');
-    expect(log).toEqual('[INFO] hello world');
+    expect(log).toEqual('[INFO] hello world\n');
   });
 
   it('should add timestamp to logs if provided', () => {
@@ -34,7 +34,7 @@ describe('FileHandler', () => {
     };
     fileHandler.handle(payload);
     const log = readFileSync(path, 'utf-8');
-    expect(log).toEqual(`[${getTimeStamp(timestamp)}] [INFO] hello world`);
+    expect(log).toEqual(`[${getTimeStamp(timestamp)}] [INFO] hello world\n`);
   });
 
   it('should add metadata to logs if provided', () => {


### PR DESCRIPTION
Fix the new line issue when a log without metadata is being sent to file.
