### PR TITLE
Refactor: change handler to transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@
 ![GitHub](https://img.shields.io/github/license/origranot/ts-logger)
 
 A logging library designed to simplify the process of logging in your TypeScript
-applications. With zero dependencies and features such as five log levels, custom log
-handlers, method decoration options, timestamps, and log level thresholding, you'll have
+applications. With zero dependencies and features such as five log levels, custom transports, method decoration options, timestamps, and log level thresholding, you'll have
 greater control over your log output.
 
-Our library also provides the flexibility to extend its functionality through custom log
-handlers, enabling you to meet the specific needs of your project. Say goodbye to
+Our library also provides the flexibility to extend its functionality through custom
+transports, enabling you to meet the specific needs of your project. Say goodbye to
 cluttered and unorganized logs and get started with ts-logger today!💪
 
 ## Features :star:
@@ -18,8 +17,8 @@ cluttered and unorganized logs and get started with ts-logger today!💪
 - Supports logging at five different levels (:bug: DEBUG, :information_source: INFO,
   :warning: WARN, :exclamation: ERROR, :fire: FATAL).
 - Zero dependencies 🚫
-- Support for custom log handlers to extend the functionality of the library. 💬
-- Support console, json and file log handlers out of the box. 📦
+- Support for custom log transports to extend the functionality of the library. 💬
+- Support console, json and file transports out of the box. 📦
 - Ability to decorate class methods to log their arguments, return values, and execution
   time. 📊
 - Option to include timestamps in logs. 🕰️
@@ -60,7 +59,7 @@ logger.info('You can also pass variables', {
 - timeStamps (Boolean): Whether to include timestamps in logs (default: false).
 - threshold (LOG_LEVEL): The log level threshold, logs with a lower level than the
   threshold will be ignored (default: 'DEBUG').
-- handlers: Array of handlers to process and log the data. (default: ConsoleHandler)
+- transports: Array of transports to process and log the data. (default: ConsoleTransport)
 
 ### Decorated functions example
 
@@ -93,56 +92,56 @@ example.exampleMethod(1, 2);
 - executionTime (Boolean): Whether to calculate and print the function execution time.
   (default: false)
 
-### Log handlers
+### Log transports
 
-This library provides a few built-in log handlers that can be used out of the box:
+This library provides a few built-in log transports that can be used out of the box:
 
-- Console handler: This handler outputs log messages to the console.
-- File handler: This handler writes log messages to a file on disk.
-- JSON handler: This handler outputs log messages in JSON format, which can be easily
+- Console: This transport outputs log messages to the console.
+- File: This transport writes log messages to a file on disk.
+- JSON: This transport outputs log messages in JSON format, which can be easily
   processed by other systems.
 
-Here's an example of how to use the built-in log handlers:
+Here's an example of how to use the built-in log transports:
 
 ```typescript
-import { Logger, ConsoleHandler, FileHandler, JsonHandler } from '@origranot/ts-logger';
+import { Logger, ConsoleTransport, FileTransport, JsonTransport } from '@origranot/ts-logger';
 
 // Create an instance of the console logger
-const consoleHandler = new ConsoleHandler();
+const consoleTransport = new ConsoleTransport();
 
 // Create an instance of the JSON logger
-const jsonHandler = new JsonHandler();
+const jsonTransport = new JsonTransport();
 
 /*
-  Note: The file handler will create the file if it doesn't exist, and append to it if it does.
-  We can also provide log rotation options to the file handler, which will automatically
+  Note: The file transport will create the file if it doesn't exist, and append to it if it does.
+  We can also provide log rotation options to the file transport, which will automatically
   rotate the log file according to the date.
 */
-const fileHandler = new FileHandler({ path: 'logs/app.log'});
+const fileTransport = new FileTransport({ path: 'logs/app.log'});
 
 const logger = new Logger({
   timeStamps: true
-  handlers: [consoleHandler, jsonHandler, fileHandler]
+  transports: [consoleTransport, jsonTransport, fileTransport]
 });
 
 /*
-  Log messages will be handled by all three handlers:
-  - The console handler will output the log message to the console.
-  - The JSON handler will output the log message to the console in JSON format.
-  - The file handler will write the log message to the file.
+  Log messages will be handled by all three transports:
+  - The console transport will output the log message to the console.
+  - The JSON transport will output the log message to the console in JSON format.
+  - The file transport will write the log message to the file.
 */
 logger.info('Application started');
 ```
 
-Note that you can add multiple handlers to a single logger, so that log messages can be
-sent to multiple outputs. You can also create custom log handlers by implementing the
-LogHandler interface as shown below:
+Note that you can add multiple transports to a single logger, so that log messages can be
+sent to multiple outputs. You can also create custom log transports by implementing the
+```Transport``` interface as shown below:
 
 ```typescript
-import { Logger, HandlerPayload } from '@origranot/ts-logger';
+import { Logger, TransportPayload } from '@origranot/ts-logger';
 
-export class CustomHandler implements LogHandler {
-  handle(payload: HandlerPayload) {
+export class CustomTransport implements Transport {
+  handle(payload: TransportPayload) {
     console.log(`[${payload.timestamp}] - ${payload.message}`);
   }
 }

--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ cluttered and unorganized logs and get started with ts-logger today!💪
 ```typescript
 import { Logger } from '@origranot/ts-logger';
 
-const logger = new Logger({
-  timeStamps: true
-});
+const logger = new Logger();
 
 logger.debug('Debug message');
 logger.info('Info message');
@@ -56,7 +54,7 @@ logger.info('You can also pass variables', {
 
 ### Optional parameters
 
-- timeStamps (Boolean): Whether to include timestamps in logs (default: false).
+- timeStamps (Boolean): Whether to include timestamps in logs (default: true).
 - threshold (LOG_LEVEL): The log level threshold, logs with a lower level than the
   threshold will be ignored (default: 'DEBUG').
 - transports: Array of transports to process and log the data. (default: ConsoleTransport)
@@ -66,7 +64,7 @@ logger.info('You can also pass variables', {
 ```typescript
 import { Logger, LOG_LEVEL } from '@origranot/ts-logger';
 
-const logger = new Logger({ timeStamps: true });
+const logger = new Logger();
 
 class ExampleClass {
   @logger.decorate(LOG_LEVEL.INFO, { executionTime: true })
@@ -120,7 +118,6 @@ const jsonTransport = new JsonTransport();
 const fileTransport = new FileTransport({ path: 'logs/app.log'});
 
 const logger = new Logger({
-  timeStamps: true
   transports: [consoleTransport, jsonTransport, fileTransport]
 });
 

--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -1,6 +1,6 @@
 import { Logger, LOG_LEVEL } from '../src';
 
-const logger = new Logger({ timeStamps: true });
+const logger = new Logger();
 
 class Calculator {
   @logger.decorate(LOG_LEVEL.INFO, { executionTime: true })

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,3 +1,0 @@
-export * from './console.handler';
-export * from './json.handler';
-export * from './file.handler';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * from './enums';
 export * from './logger';
-export * from './log-handler';
-export * from './handlers';
+export * from './transport';
+export * from './transports';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -20,12 +20,11 @@ export interface LogOptions {
 
 export class Logger {
   constructor(loggerOptions?: LoggerOptions) {
-    this.options = loggerOptions || {
-      threshold: LOG_LEVEL.DEBUG
-    };
+    this.options = loggerOptions || {};
 
     // Default timestamp to be true if not provided
     this.options.timeStamps = this.options.timeStamps === undefined ? true : this.options.timeStamps;
+    this.options.threshold = this.options.threshold || LOG_LEVEL.DEBUG;
     this.options.transports = this.options.transports || [new ConsoleTransport()];
   }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,11 +1,11 @@
+import { ConsoleTransport } from './transports/console.transport';
 import { LOG_LEVEL } from './enums';
-import { LogHandler } from './log-handler';
-import { ConsoleHandler } from './handlers';
+import { Transport } from './transport';
 
 export interface LoggerOptions {
   timeStamps?: boolean;
   threshold?: LOG_LEVEL;
-  handlers?: LogHandler[];
+  transports?: Transport[];
 }
 
 export interface DecoratorOptions {
@@ -24,7 +24,7 @@ export class Logger {
       threshold: LOG_LEVEL.DEBUG
     };
 
-    this.options.handlers = this.options.handlers || [new ConsoleHandler()];
+    this.options.transports = this.options.transports || [new ConsoleTransport()];
   }
 
   private options: LoggerOptions;
@@ -34,8 +34,8 @@ export class Logger {
       return;
     }
 
-    for (const handler of this.options.handlers!) {
-      handler.handle({
+    for (const transport of this.options.transports!) {
+      transport.handle({
         level,
         message,
         metadata: options?.metadata,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -24,6 +24,8 @@ export class Logger {
       threshold: LOG_LEVEL.DEBUG
     };
 
+    // Default timestamp to be true if not provided
+    this.options.timeStamps = this.options.timeStamps === undefined ? true : this.options.timeStamps;
     this.options.transports = this.options.transports || [new ConsoleTransport()];
   }
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,6 +1,6 @@
 import { LOG_LEVEL } from './enums';
 
-export interface HandlerPayload {
+export interface TransportPayload {
   level: LOG_LEVEL;
   message: string;
   metadata?: {
@@ -9,6 +9,6 @@ export interface HandlerPayload {
   timestamp?: Date;
 }
 
-export interface LogHandler {
-  handle(payload: HandlerPayload): void;
+export interface Transport {
+  handle(payload: TransportPayload): void;
 }

--- a/src/transports/console.transport.ts
+++ b/src/transports/console.transport.ts
@@ -1,8 +1,8 @@
 import { COLOR, LOG_LEVEL } from '../enums';
-import { HandlerPayload, LogHandler } from '../log-handler';
+import { Transport, TransportPayload } from './../transport';
 import { colorize, getTimeStamp } from '../utils';
 
-export class ConsoleHandler implements LogHandler {
+export class ConsoleTransport implements Transport {
   private LOG_LEVEL_COLORS = {
     [LOG_LEVEL.DEBUG]: COLOR.BLUE,
     [LOG_LEVEL.INFO]: COLOR.GREEN,
@@ -11,7 +11,7 @@ export class ConsoleHandler implements LogHandler {
     [LOG_LEVEL.FATAL]: COLOR.WHITE
   };
 
-  handle({ level, message, metadata, timestamp }: HandlerPayload): void {
+  handle({ level, message, metadata, timestamp }: TransportPayload): void {
     let prefix: string = '';
     prefix += timestamp ? `[${getTimeStamp(timestamp)}] ` : '';
     prefix += `${colorize(this.LOG_LEVEL_COLORS[level], level)}`;

--- a/src/transports/file.transport.ts
+++ b/src/transports/file.transport.ts
@@ -1,23 +1,23 @@
-import { HandlerPayload, LogHandler } from '../log-handler';
+import { Transport, TransportPayload } from './../transport';
 import { getTimeStamp, stringify } from '../utils';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
 
 type LOG_ROTATION = 'daily' | 'weekly' | 'monthly';
 
-export interface FileHandlerOptions {
+export interface FileTransportOptions {
   path: string;
   logRotation?: LOG_ROTATION;
 }
 
-export class FileHandler implements LogHandler {
-  constructor(options: FileHandlerOptions) {
+export class FileTransport implements Transport {
+  constructor(options: FileTransportOptions) {
     this.options = options;
   }
 
-  private options: FileHandlerOptions;
+  private options: FileTransportOptions;
 
-  handle({ level, message, metadata, timestamp }: HandlerPayload): void {
+  handle({ level, message, metadata, timestamp }: TransportPayload): void {
     let filePath = this.options.path;
 
     if (this.options.logRotation) {

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -1,0 +1,3 @@
+export * from './console.transport';
+export * from './json.transport';
+export * from './file.transport';

--- a/src/transports/json.transport.ts
+++ b/src/transports/json.transport.ts
@@ -1,8 +1,8 @@
-import { HandlerPayload, LogHandler } from '../log-handler';
+import { Transport, TransportPayload } from './../transport';
 import { getTimeStamp, stringify } from '../utils';
 
-export class JsonHandler implements LogHandler {
-  handle(payload: HandlerPayload): void {
+export class JsonTransport implements Transport {
+  handle(payload: TransportPayload): void {
     const { timestamp } = payload;
     const logData = {
       ...payload,

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -5,7 +5,7 @@ describe('Logger', () => {
   let logger: Logger;
 
   beforeEach(() => {
-    logger = new Logger();
+    logger = new Logger({ timeStamps: false });
   });
 
   afterEach(() => {

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -1,3 +1,5 @@
+import { JsonTransport } from './../src/transports/json.transport';
+import { FileTransport } from './../src/transports/file.transport';
 import { ConsoleTransport } from './../src/transports/console.transport';
 import { Logger, LOG_LEVEL } from '../src';
 
@@ -33,6 +35,21 @@ describe('Logger', () => {
     // Default transports array should be an array with a ConsoleTransport instance in it
     expect(logger['options'].transports).toHaveLength(1);
     expect(logger['options'].transports![0]).toBeInstanceOf(ConsoleTransport);
+  });
+
+  it('should create a logger with array of transports', () => {
+    logger = new Logger({
+      transports: [new JsonTransport(), new ConsoleTransport()]
+    });
+    
+    expect(logger).toBeDefined();
+
+    // Default log level threshold should be DEBUG
+    expect(logger['options'].threshold).toBe(LOG_LEVEL.DEBUG);
+
+    expect(logger['options'].transports).toHaveLength(2);
+    expect(logger['options'].transports![0]).toBeInstanceOf(JsonTransport);
+    expect(logger['options'].transports![1]).toBeInstanceOf(ConsoleTransport);
   });
 
   describe('log', () => {

--- a/test/logger.spec.ts
+++ b/test/logger.spec.ts
@@ -1,4 +1,5 @@
-import { ConsoleHandler, Logger, LOG_LEVEL } from '../src';
+import { ConsoleTransport } from './../src/transports/console.transport';
+import { Logger, LOG_LEVEL } from '../src';
 
 describe('Logger', () => {
   let logger: Logger;
@@ -29,9 +30,9 @@ describe('Logger', () => {
     // Default log level threshold should be DEBUG
     expect(logger['options'].threshold).toBe(LOG_LEVEL.DEBUG);
 
-    // Default handlers array should be an array with a ConsoleHandler instance in it
-    expect(logger['options'].handlers).toHaveLength(1);
-    expect(logger['options'].handlers![0]).toBeInstanceOf(ConsoleHandler);
+    // Default transports array should be an array with a ConsoleTransport instance in it
+    expect(logger['options'].transports).toHaveLength(1);
+    expect(logger['options'].transports![0]).toBeInstanceOf(ConsoleTransport);
   });
 
   describe('log', () => {

--- a/test/transports/console.transport.spec.ts
+++ b/test/transports/console.transport.spec.ts
@@ -1,10 +1,10 @@
-import { ConsoleHandler, LogHandler, LOG_LEVEL } from '../../src';
+import { LOG_LEVEL, Transport, ConsoleTransport } from '../../src';
 
-describe('Console Handler', () => {
-  let handler: LogHandler;
+describe('Console Transport', () => {
+  let transport: Transport;
 
   beforeEach(() => {
-    handler = new ConsoleHandler();
+    transport = new ConsoleTransport();
   });
 
   afterEach(() => {
@@ -14,7 +14,7 @@ describe('Console Handler', () => {
   describe('handle', () => {
     it('should log the message to the console', () => {
       const spy = jest.spyOn(console, 'log');
-      handler.handle({
+      transport.handle({
         level: LOG_LEVEL.DEBUG,
         message: 'This is a debug message',
         timestamp: new Date()
@@ -26,7 +26,7 @@ describe('Console Handler', () => {
       const spy = jest.spyOn(console, 'log');
       const inputMetadata = { foo: 'bar' };
 
-      handler.handle({
+      transport.handle({
         level: LOG_LEVEL.INFO,
         message: 'This is an info message',
         metadata: inputMetadata,
@@ -42,7 +42,7 @@ describe('Console Handler', () => {
     it('should not console log the the metadata as second argument', () => {
       const spy = jest.spyOn(console, 'log');
 
-      handler.handle({
+      transport.handle({
         level: LOG_LEVEL.INFO,
         message: 'This is an info message',
         timestamp: new Date()

--- a/test/transports/file.handler.spec.ts
+++ b/test/transports/file.handler.spec.ts
@@ -1,12 +1,12 @@
-import { FileHandler, HandlerPayload, LOG_LEVEL } from '../../src';
+import { FileTransport, LOG_LEVEL, TransportPayload } from '../../src';
 import { unlinkSync, readFileSync, mkdirSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { getTimeStamp } from '../../src/utils';
 
-describe('FileHandler', () => {
+describe('File Transport', () => {
   const path = 'test/logs';
   const options = { path };
-  let fileHandler = new FileHandler(options);
+  let fileTransport = new FileTransport(options);
 
   afterEach(() => {
     // delete the log files created during each test
@@ -19,40 +19,40 @@ describe('FileHandler', () => {
   });
 
   it('should write logs to file', () => {
-    const payload: HandlerPayload = { level: LOG_LEVEL.INFO, message: 'hello world' };
-    fileHandler.handle(payload);
+    const payload: TransportPayload = { level: LOG_LEVEL.INFO, message: 'hello world' };
+    fileTransport.handle(payload);
     const log = readFileSync(path, 'utf-8');
     expect(log).toEqual('[INFO] hello world\n');
   });
 
   it('should add timestamp to logs if provided', () => {
     const timestamp = new Date();
-    const payload: HandlerPayload = {
+    const payload: TransportPayload = {
       level: LOG_LEVEL.INFO,
       message: 'hello world',
       timestamp
     };
-    fileHandler.handle(payload);
+    fileTransport.handle(payload);
     const log = readFileSync(path, 'utf-8');
     expect(log).toEqual(`[${getTimeStamp(timestamp)}] [INFO] hello world\n`);
   });
 
   it('should add metadata to logs if provided', () => {
     const metadata = { key: 'value' };
-    const payload: HandlerPayload = {
+    const payload: TransportPayload = {
       level: LOG_LEVEL.INFO,
       message: 'hello world',
       metadata
     };
-    fileHandler.handle(payload);
+    fileTransport.handle(payload);
     const log = readFileSync(path, 'utf-8');
     expect(log).toEqual('[INFO] hello world\n{\n  "key": "value"\n}\n');
   });
 
   it('should handle daily log rotation', () => {
-    fileHandler = new FileHandler({ ...options, logRotation: 'daily' });
+    fileTransport = new FileTransport({ ...options, logRotation: 'daily' });
 
-    const payload: HandlerPayload = {
+    const payload: TransportPayload = {
       level: LOG_LEVEL.ERROR,
       message: 'error message',
       metadata: { key: 'value' },
@@ -65,7 +65,7 @@ describe('FileHandler', () => {
 
     jest.useFakeTimers();
     jest.setSystemTime(new Date(1999, 0, 23));
-    fileHandler.handle(payload);
+    fileTransport.handle(payload);
 
     const log = readFileSync(expectedFilePath, 'utf8');
     expect(log).toEqual(

--- a/test/transports/json.handler.spec.ts
+++ b/test/transports/json.handler.spec.ts
@@ -1,10 +1,11 @@
-import { JsonHandler, LOG_LEVEL } from '../../src';
+import { Transport } from './../../src/transport';
+import { JsonTransport, LOG_LEVEL } from '../../src';
 
-describe('Json Handler', () => {
-  let handler: JsonHandler;
+describe('Json Transport', () => {
+  let transport: Transport;
 
   beforeEach(() => {
-    handler = new JsonHandler();
+    transport = new JsonTransport();
   });
 
   afterEach(() => {
@@ -14,7 +15,7 @@ describe('Json Handler', () => {
   describe('handle', () => {
     it('should log the message in json format to the console', () => {
       const spy = jest.spyOn(console, 'log');
-      handler.handle({
+      transport.handle({
         level: LOG_LEVEL.DEBUG,
         message: 'This is a debug message',
         timestamp: new Date()
@@ -27,7 +28,7 @@ describe('Json Handler', () => {
       const spy = jest.spyOn(console, 'log');
       const inputMetadata = { foo: 'bar' };
 
-      handler.handle({
+      transport.handle({
         level: LOG_LEVEL.INFO,
         message: 'This is an info message',
         metadata: inputMetadata,
@@ -44,7 +45,7 @@ describe('Json Handler', () => {
     it('should log the message without metadata and timestamp in json format to the console', () => {
       const spy = jest.spyOn(console, 'log');
 
-      handler.handle({
+      transport.handle({
         level: LOG_LEVEL.INFO,
         message: 'This is an info message'
       });
@@ -64,7 +65,7 @@ describe('Json Handler', () => {
       const inputMetadata = { circular: {} };
       inputMetadata.circular = inputMetadata;
 
-      handler.handle({
+      transport.handle({
         level: LOG_LEVEL.INFO,
         message: 'This is an info message',
         metadata: inputMetadata


### PR DESCRIPTION
- Changed handlers name to be called transports as it more accurate.
- Made the default timestamps option to be true.
- Add some more unit tests.