### PR TITLE
refactor(logger): ability to pass rest parameters instead of fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,22 @@
 ![npm bundle size](https://img.shields.io/bundlephobia/min/@origranot/ts-logger)
 ![GitHub](https://img.shields.io/github/license/origranot/ts-logger)
 
-A logging library designed to simplify the process of logging in your TypeScript
-applications. With zero dependencies and features such as five log levels, custom transports, method decoration options, timestamps, and log level thresholding, you'll have
-greater control over your log output.
+A logging library designed to simplify the process of logging in your TypeScript applications. With zero
+dependencies and features such as five log levels, custom transports, method decoration options,
+timestamps, and log level thresholding, you'll have greater control over your log output.
 
-Our library also provides the flexibility to extend its functionality through custom
-transports, enabling you to meet the specific needs of your project. Say goodbye to
-cluttered and unorganized logs and get started with ts-logger today!💪
+Our library also provides the flexibility to extend its functionality through custom transports, enabling
+you to meet the specific needs of your project. Say goodbye to cluttered and unorganized logs and get
+started with ts-logger today!💪
 
 ## Features :star:
 
-- Supports logging at five different levels (:bug: DEBUG, :information_source: INFO,
-  :warning: WARN, :exclamation: ERROR, :fire: FATAL).
+- Supports logging at five different levels (:bug: DEBUG, :information_source: INFO, :warning: WARN,
+  :exclamation: ERROR, :fire: FATAL).
 - Zero dependencies 🚫
 - Support for custom log transports and formatters to extend the functionality of the library. 💬
 - Support multiple log transports out of the box. 📦 (Console, UDP and File)
-- Ability to decorate class methods to log their arguments, return values, and execution
-  time. 📊
+- Ability to decorate class methods to log their arguments, return values, and execution time. 📊
 - Option to include timestamps in logs. 🕰️
 - Option to set log level threshold. 🎛️
 - Option to log execution time of decorated functions. ⏱️
@@ -45,18 +44,16 @@ logger.warn('Warn message');
 logger.error('Error message');
 logger.fatal('Fatal message');
 
-logger.info('You can also pass variables', {
-  metadata: {
-    foo: 'baz'
-  }
+logger.info('You can also log objects', {
+  foo: 'baz'
 });
 ```
 
 ### Optional parameters
 
 - timeStamps (Boolean): Whether to include timestamps in logs (default: true).
-- threshold (LOG_LEVEL): The log level threshold, logs with a lower level than the
-  threshold will be ignored (default: 'DEBUG').
+- threshold (LOG_LEVEL): The log level threshold, logs with a lower level than the threshold will be
+  ignored (default: 'DEBUG').
 - transports: Array of transports to process and log the data. (default: ConsoleTransport)
 - formatter: An instance of a formatter to format the log message. (default: SimpleFormatter)
 
@@ -78,7 +75,8 @@ const example = new ExampleClass();
 example.exampleMethod(1, 2);
 
 /* 
-  Output: [2022-01-01 00:00:00] [exampleMethod] {
+  Output: [2022-01-01 00:00:00] [exampleMethod]
+  {
     args: [1, 2],
     returns: 3,
     executionTime: 3ms
@@ -88,8 +86,7 @@ example.exampleMethod(1, 2);
 
 ### Optional parameters
 
-- executionTime (Boolean): Whether to calculate and print the function execution time.
-  (default: false)
+- executionTime (Boolean): Whether to calculate and print the function execution time. (default: false)
 
 ### Log transports
 
@@ -112,7 +109,7 @@ const consoleTransport = new ConsoleTransport();
   We can also provide log rotation options to the file transport, which will automatically
   rotate the log file according to the date.
 */
-const fileTransport = new FileTransport({ path: 'logs/app.log'});
+const fileTransport = new FileTransport({ path: 'logs/app.log' });
 
 const logger = new Logger({
   transports: [consoleTransport, fileTransport]
@@ -125,12 +122,12 @@ const logger = new Logger({
 */
 logger.info('Application started');
 ```
-> **Note:** There is a file in the examples directory that demonstrates how to use
-the built-in UDP transport to send log messages to Splunk.
 
-You can add multiple transports to a single logger, so that log messages can be
-sent to multiple outputs. You can also create custom log transports by implementing the
-```Transport``` interface as shown below:
+> **Note:** There is a file in the examples directory that demonstrates how to use the built-in UDP
+> transport to send log messages to Splunk.
+
+You can add multiple transports to a single logger, so that log messages can be sent to multiple outputs.
+You can also create custom log transports by implementing the `Transport` interface as shown below:
 
 ```typescript
 import { Logger, TransportPayload } from '@origranot/ts-logger';

--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -16,10 +16,8 @@ class Calculator {
   @logger.decorate(LOG_LEVEL.WARN)
   void() {
     logger.warn('This is a warning from the void method!', {
-      metadata: {
-        foo: 'bar',
-        baz: 'qux'
-      }
+      foo: 'bar',
+      baz: 'qux'
     });
   }
 }

--- a/src/formatters/json.formatter.ts
+++ b/src/formatters/json.formatter.ts
@@ -2,13 +2,28 @@ import { Formatter, FormatterPayload } from '../interfaces';
 import { getTimeStamp, stringify } from '../utils';
 
 export class JsonFormatter implements Formatter {
-  format(payload: FormatterPayload): string {
-    const { timestamp } = payload;
+  format({ level, timestamp, args }: FormatterPayload): string {
     const logData = {
-      ...payload,
+      level,
+      ...this.parse(args),
       ...(timestamp && { timestamp: getTimeStamp(timestamp) })
     };
 
     return stringify(logData);
+  }
+
+  parse(args: unknown[]): object {
+    return args.reduce((acc: object, arg: unknown, index: number) => {
+      let argString = arg;
+      if (typeof arg === 'object') {
+        const argObject = arg as Object;
+
+        // Check if the object is empty
+        if (Object.keys(argObject).length === 0) {
+          return acc;
+        }
+      }
+      return Object.assign(acc, { [index]: argString });
+    }, {}) as object;
   }
 }

--- a/src/formatters/simple.formatter.ts
+++ b/src/formatters/simple.formatter.ts
@@ -2,17 +2,30 @@ import { Formatter, FormatterPayload } from '../interfaces';
 import { colorize, getTimeStamp, LOG_LEVEL_COLORS, stringify } from '../utils';
 
 export class SimpleFormatter implements Formatter {
-
-  format({ level, message, metadata, timestamp }: FormatterPayload): string {
+  format({ level, args, timestamp }: FormatterPayload): string {
     let prefix: string = '';
     prefix += timestamp ? `[${getTimeStamp(timestamp)}] ` : '';
     prefix += `${colorize(LOG_LEVEL_COLORS[level], level)}`;
 
-    let finalLog = `${prefix} ${message}`;
-    if (metadata) {
-      finalLog += `\n${stringify(metadata, 2)}`;
-    }
+    const message = this.parse(args);
 
-    return finalLog;
+    return `${prefix}${message.length ? ' ' : ''}${message}`;
+  }
+
+  parse(args: unknown[]) {
+    return args.reduce((acc: string, arg: unknown) => {
+      let argString = arg;
+      if (typeof arg === 'object') {
+        const argObject = arg as Object;
+
+        // Check if the object is empty
+        if (Object.keys(argObject).length === 0) {
+          return acc;
+        }
+
+        argString = stringify(argObject, 2);
+      }
+      return (acc += acc.length ? `\n${argString}` : `${argString}`);
+    }, '');
   }
 }

--- a/src/interfaces/formatter.ts
+++ b/src/interfaces/formatter.ts
@@ -2,13 +2,11 @@ import { LOG_LEVEL } from '../enums';
 
 export interface FormatterPayload {
   level: LOG_LEVEL;
-  message: string;
-  metadata?: {
-    [key: string]: any;
-  };
+  args: unknown[];
   timestamp?: Date;
 }
 
 export interface Formatter {
   format(payload: FormatterPayload): string;
+  parse(args: unknown[]): string | object;
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -14,12 +14,6 @@ export interface DecoratorOptions {
   executionTime?: boolean;
 }
 
-export interface LogOptions {
-  metadata?: {
-    [name: string]: any;
-  };
-}
-
 export class Logger {
   constructor(loggerOptions?: LoggerOptions) {
     this.options = loggerOptions || {};
@@ -33,15 +27,14 @@ export class Logger {
 
   private options: LoggerOptions;
 
-  private log(level: LOG_LEVEL, message: string, options?: LogOptions) {
+  private log(level: LOG_LEVEL, ...args: unknown[]) {
     if (level < this.options.threshold!) {
       return;
     }
 
     const formattedLog = this.options.formatter!.format({
       level,
-      message,
-      metadata: options?.metadata,
+      args,
       timestamp: this.options.timeStamps ? new Date() : undefined
     });
 
@@ -79,25 +72,25 @@ export class Logger {
           metadata.executionTime = `${end - start}ms`;
         }
 
-        this.log(level, `[${propertyKey}]`, { metadata });
+        this.log(level, `[${propertyKey}]`, { ...metadata });
         return result;
       };
     };
   }
 
-  debug(message: string, options?: LogOptions) {
-    this.log(LOG_LEVEL.DEBUG, message, options);
+  debug(...args: unknown[]) {
+    this.log(LOG_LEVEL.DEBUG, ...args);
   }
-  info(message: string, options?: LogOptions) {
-    this.log(LOG_LEVEL.INFO, message, options);
+  info(...args: unknown[]) {
+    this.log(LOG_LEVEL.INFO, ...args);
   }
-  warn(message: string, options?: LogOptions) {
-    this.log(LOG_LEVEL.WARN, message, options);
+  warn(...args: unknown[]) {
+    this.log(LOG_LEVEL.WARN, ...args);
   }
-  error(message: string, options?: LogOptions) {
-    this.log(LOG_LEVEL.ERROR, message, options);
+  error(...args: unknown[]) {
+    this.log(LOG_LEVEL.ERROR, ...args);
   }
-  fatal(message: string, options?: LogOptions) {
-    this.log(LOG_LEVEL.FATAL, message, options);
+  fatal(...args: unknown[]) {
+    this.log(LOG_LEVEL.FATAL, ...args);
   }
 }

--- a/test/formatters/json.formatter.spec.ts
+++ b/test/formatters/json.formatter.spec.ts
@@ -1,5 +1,5 @@
-import { FormatterPayload, JsonFormatter, LOG_LEVEL } from "../../src";
-import { getTimeStamp, stringify } from "../../src/utils";
+import { FormatterPayload, JsonFormatter, LOG_LEVEL } from '../../src';
+import { getTimeStamp, stringify } from '../../src/utils';
 
 describe('JsonFormatter', () => {
   let formatter: JsonFormatter;
@@ -7,20 +7,18 @@ describe('JsonFormatter', () => {
   beforeEach(() => {
     formatter = new JsonFormatter();
   });
-  
 
   it('should format the log payload as a JSON string', () => {
     const payload: FormatterPayload = {
       level: LOG_LEVEL.DEBUG,
-      message: 'This is a test log',
-      metadata: {
-        extraData: 'test data'
-      },
+      args: ['This is a test log', { extraData: 'test data' }],
       timestamp: new Date()
     };
 
     const expectedOutput = stringify({
-      ...payload,
+      level: payload.level,
+      0: payload.args[0],
+      1: payload.args[1],
       ...{ timestamp: getTimeStamp(payload.timestamp!) }
     });
 
@@ -32,14 +30,45 @@ describe('JsonFormatter', () => {
   it('should not include the timestamp if it is not present in the payload', () => {
     const payload: FormatterPayload = {
       level: LOG_LEVEL.DEBUG,
-      message: 'This is another test log',
-      metadata: {
-        additionalData: 123
-      }
+      args: ['This is another test log', { additionalData: 123 }]
     };
 
-    const expectedOutput = stringify(payload);
+    const expectedOutput = stringify({
+      level: payload.level,
+      0: payload.args[0],
+      1: payload.args[1],
+    });
+    const output = formatter.format(payload);
 
+    expect(output).toEqual(expectedOutput);
+  });
+
+  it('should format more than one object provided', () => {
+    const payload: FormatterPayload = {
+      level: LOG_LEVEL.DEBUG,
+      args: ['This is another test log', { additionalData: 123 }, { foo: 'bar' }]
+    };
+
+    const expectedOutput = stringify({
+      level: payload.level,
+      0: payload.args[0],
+      1: payload.args[1],
+      2: payload.args[2],
+    });
+    const output = formatter.format(payload);
+
+    expect(output).toEqual(expectedOutput);
+  });
+
+  it('should format if there is no args provided', () => {
+    const payload: FormatterPayload = {
+      level: LOG_LEVEL.DEBUG,
+      args: []
+    };
+
+    const expectedOutput = stringify({
+      level: payload.level,
+    });
     const output = formatter.format(payload);
 
     expect(output).toEqual(expectedOutput);

--- a/test/formatters/simple.formatter.spec.ts
+++ b/test/formatters/simple.formatter.spec.ts
@@ -11,14 +11,14 @@ describe('SimpleFormatter', () => {
   it('should format the log message in the correct format', () => {
     const payload = {
       level: LOG_LEVEL.DEBUG,
-      message: 'This is a debug message',
+      args: ['This is a debug message'],
       timestamp: new Date()
     };
 
     const expectedMessage = `[${getTimeStamp(payload.timestamp)}] ${colorize(
       LOG_LEVEL_COLORS[LOG_LEVEL.DEBUG],
       LOG_LEVEL.DEBUG
-    )} ${payload.message}`;
+    )} ${payload.args[0]}`;
 
     const result = formatter.format(payload);
 
@@ -28,15 +28,14 @@ describe('SimpleFormatter', () => {
   it('should format the log message with metadata if it is present', () => {
     const payload = {
       level: LOG_LEVEL.DEBUG,
-      message: 'This is a debug message',
-      metadata: { foo: 'bar' },
+      args: ['This is a debug message', { foo: 'bar' }],
       timestamp: new Date()
     };
 
     const expectedMessage = `[${getTimeStamp(payload.timestamp)}] ${colorize(
       LOG_LEVEL_COLORS[LOG_LEVEL.DEBUG],
       LOG_LEVEL.DEBUG
-    )} ${payload.message}\n${stringify(payload.metadata, 2)}`;
+    )} ${payload.args[0]}\n${stringify(payload.args[1], 2)}`;
 
     const result = formatter.format(payload);
 
@@ -47,12 +46,29 @@ describe('SimpleFormatter', () => {
     formatter = new SimpleFormatter();
     const payload = {
       level: LOG_LEVEL.DEBUG,
-      message: 'This is a debug message'
+      args: ['This is a debug message'],
     };
 
     const expectedMessage = `${colorize(LOG_LEVEL_COLORS[LOG_LEVEL.DEBUG], LOG_LEVEL.DEBUG)} ${
-      payload.message
+      payload.args[0]
     }`;
+
+    const result = formatter.format(payload);
+
+    expect(result).toBe(expectedMessage);
+  });
+
+  it('should format the log message if there are no args provided', () => {
+    const payload = {
+      level: LOG_LEVEL.DEBUG,
+      args: [],
+      timestamp: new Date()
+    };
+
+    const expectedMessage = `[${getTimeStamp(payload.timestamp)}] ${colorize(
+      LOG_LEVEL_COLORS[LOG_LEVEL.DEBUG],
+      LOG_LEVEL.DEBUG
+    )}`;
 
     const result = formatter.format(payload);
 


### PR DESCRIPTION
Now you can pass as many parameters as you like to the log functions.

- Support rest parameters instead of fixed.
- Updated the tests